### PR TITLE
fix: Update the nodejs buildpack in the manifest file

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -10,4 +10,4 @@ applications:
   env:
     WEATHER_API_KEY: <YOUR_API_KEY>
     NPM_CONFIG_PRODUCTION: false
-  buildpack: sdk-for-nodejs
+  buildpack: https://github.com/cloudfoundry/nodejs-buildpack


### PR DESCRIPTION
Fixes - https://github.com/Call-for-Code/weather-api-nodejs/issues/26

After updating the manifest file I was able to successfully run `ibmcloud cf push --no-start`.

```
weather-api-nodejs git:(main) ✗ ibmcloud cf push --no-start
Invoking 'cf push --no-start'...

Using manifest file /Users/akash/github/weather-api-nodejs/manifest.yml
Deprecation warning: Use of 'buildpack' attribute in manifest is deprecated in favor of 'buildpacks'. Please see https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#deprecated for alternatives and other app manifest deprecations. This feature will be removed in the future.

Getting app info...
Creating app with these attributes...
+ name:                weather-api-nodejs
  path:                /Users/akash/github/weather-api-nodejs
  buildpacks:
+   https://github.com/cloudfoundry/nodejs-buildpack
+ command:             npm start
+ health check type:   process
+ instances:           1
+ memory:              256M
  env:
+   NPM_CONFIG_PRODUCTION
+   WEATHER_API_KEY

Creating app weather-api-nodejs...
Comparing local files to remote cache...
Packaging files to upload...
Uploading files...
 1.92 MiB / 1.92 MiB [================================] 100.00% 3s

Waiting for API to complete processing files...

name:              weather-api-nodejs
requested state:   stopped
routes:            
last uploaded:     
stack:             
buildpacks:        

type:            web
instances:       0/1
memory usage:    256M
start command:   npm start
     state   since                  cpu    memory   disk     details
#0   down    2021-10-28T13:34:10Z   0.0%   0 of 0   0 of 0 
```

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>